### PR TITLE
Avoid extensive linking on incremental build.

### DIFF
--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -12,6 +12,7 @@ do
     x64 | amd64)
             arch=x86_64
             archdir=x64
+            cross_prefix=x86_64-w64-mingw32-
             ;;
     quick)
             clean_build=false
@@ -32,19 +33,11 @@ make_dirs() (
   fi
 )
 
-strip_libs() {
-  if [ "${arch}" == "x86_64" ]; then
-    x86_64-w64-mingw32-strip lib*/*-lav-*.dll
-  else
-    strip lib*/*-lav-*.dll
-  fi
-}
-
 copy_libs() (
-  cp lib*/*-lav-*.dll ../bin_${archdir}
-  cp lib*/*.lib ../bin_${archdir}/lib
-  cp lib*/*-lav-*.dll ../bin_${archdir}d
-  cp lib*/*.lib ../bin_${archdir}d/lib
+  install -s --strip-program=${cross_prefix}strip lib*/*-lav-*.dll ../bin_${archdir}
+  cp -u lib*/*.lib ../bin_${archdir}/lib
+  install -s --strip-program=${cross_prefix}strip lib*/*-lav-*.dll ../bin_${archdir}d
+  cp -u lib*/*.lib ../bin_${archdir}d/lib
 )
 
 clean() (
@@ -99,7 +92,7 @@ configure() (
   EXTRA_CFLAGS="-D_WIN32_WINNT=0x0502 -DWINVER=0x0502 -I../thirdparty/include"
   EXTRA_LDFLAGS=""
   if [ "${arch}" == "x86_64" ]; then
-    OPTIONS="${OPTIONS} --enable-cross-compile --cross-prefix=x86_64-w64-mingw32- --target-os=mingw32"
+    OPTIONS="${OPTIONS} --enable-cross-compile --cross-prefix=${cross_prefix} --target-os=mingw32"
     EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -L../thirdparty/lib64"
   else
     OPTIONS="${OPTIONS} --cpu=i686"
@@ -134,7 +127,6 @@ fi
 ## Only if configure succeeded, actually build
 if ! $clean_build || [ ${CONFIGRETVAL} -eq 0 ]; then
   build &&
-  strip_libs &&
   copy_libs
 fi
 

--- a/build_ffmpeg_msvc.sh
+++ b/build_ffmpeg_msvc.sh
@@ -29,9 +29,9 @@ make_dirs() (
 )
 
 copy_libs() (
-  cp lib*/*-lav-*.dll ../bin_${archdir}d
-  cp lib*/*-lav-*.pdb ../bin_${archdir}d
-  cp lib*/*.lib ../bin_${archdir}d/lib
+  cp -u lib*/*-lav-*.dll ../bin_${archdir}d
+  cp -u lib*/*-lav-*.pdb ../bin_${archdir}d
+  cp -u lib*/*.lib ../bin_${archdir}d/lib
 )
 
 clean() (


### PR DESCRIPTION
- Don't strip .dll files in build directory.
- Copy .lib files only if they were modified.

What I did here is basically prevent any linking if you run build again on unmodified tree. 

It will strip twice, but stripping is fast and well you already copy twice the same libs to different places. At first I wanted to change it, but I understand that you want this sorted with one `build_ffmpeg.sh` call.
