### PR TITLE
Increase MAX_PACKETS_IN_QUEUE to something more reasonable.

### DIFF
--- a/demuxer/LAVSplitter/PacketQueue.h
+++ b/demuxer/LAVSplitter/PacketQueue.h
@@ -22,7 +22,7 @@
 #include <deque>
 
 #define MIN_PACKETS_IN_QUEUE 50           // Below this is considered "drying pin"
-#define MAX_PACKETS_IN_QUEUE 350
+#define MAX_PACKETS_IN_QUEUE 35000
 
 // 192MB maximum for a single queue
 #define MAX_QUEUE_SIZE       (192 * 1024 * 1024)


### PR DESCRIPTION
Unfortunately this value has been way too low for years, resulting in dropouts on wireless networks. More recently, this has been significantly impacting my experience on various services such as Twitch. Increasing this value as per https://superuser.com/questions/842203/how-to-make-mpc-hc-to-cache-more-aggressively shows this helping a number of people on x86. I hope this helps others as well.

For reference, if DTS is utilized later on, the value is increased by 30x, which supports this value being insanely low by default.
